### PR TITLE
Fix login lockout and auth audit coverage for /api/user/token/

### DIFF
--- a/Piicasso/backend/wordgen/middleware.py
+++ b/Piicasso/backend/wordgen/middleware.py
@@ -19,6 +19,17 @@ from django.core.cache import cache
 
 logger = logging.getLogger('wordgen.security')
 
+AUTH_EXEMPT_PREFIXES = (
+    '/api/token/',
+    '/api/auth/',
+    '/api/user/token/',
+    '/api/user/auth/',
+)
+LOGIN_ENDPOINTS = frozenset({
+    '/api/token/',
+    '/api/user/token/',
+})
+
 
 class RequestIDMiddleware(MiddlewareMixin):
     """
@@ -43,9 +54,7 @@ class PolicyViolationMiddleware(MiddlewareMixin):
     auth and messaging endpoints so they can still appeal or communicate.
     """
     # Paths that suspended users are still allowed to access
-    EXEMPT_PREFIXES = (
-        '/api/token/',
-        '/api/auth/',
+    EXEMPT_PREFIXES = AUTH_EXEMPT_PREFIXES + (
         '/api/operations/messages/',
         '/api/health/',
     )
@@ -76,9 +85,8 @@ class MaintenanceModeMiddleware(MiddlewareMixin):
     """
     EXEMPT_PREFIXES = (
         '/api/health/',
-        '/api/token/',
         '/admin/',
-    )
+    ) + AUTH_EXEMPT_PREFIXES
 
     def process_request(self, request):
         # Only check if the app is loaded (avoid import errors during startup)
@@ -132,8 +140,12 @@ class AccountLockoutMiddleware(MiddlewareMixin):
     MAX_ATTEMPTS = 5
     LOCKOUT_SECONDS = 900  # 15 minutes
 
+    @staticmethod
+    def _is_login_request(request):
+        return request.method == 'POST' and request.path in LOGIN_ENDPOINTS
+
     def process_request(self, request):
-        if request.path != '/api/token/' or request.method != 'POST':
+        if not self._is_login_request(request):
             return None
 
         try:
@@ -160,7 +172,7 @@ class AccountLockoutMiddleware(MiddlewareMixin):
             )
 
     def process_response(self, request, response):
-        if request.path != '/api/token/' or request.method != 'POST':
+        if not self._is_login_request(request):
             return response
 
         try:
@@ -251,7 +263,7 @@ class SecurityLoggingMiddleware(MiddlewareMixin):
             self._log_pii_submission(request, response, duration, request_id)
 
         # Audit: auth attempts
-        if request.path == '/api/token/' and request.method == 'POST':
+        if request.method == 'POST' and request.path in LOGIN_ENDPOINTS:
             self._log_auth_attempt(request, response, duration, request_id)
 
         # Monitor: 4xx/5xx

--- a/Piicasso/backend/wordgen/tests.py
+++ b/Piicasso/backend/wordgen/tests.py
@@ -88,6 +88,7 @@ class AuthTokenTest(TestCase):
             username="authuser", password="StrongPass1!", email="auth@test.com"
         )
         self.client = APIClient()
+        cache.clear()
 
     def test_login_success(self):
         response = self.client.post(
@@ -142,6 +143,29 @@ class AuthTokenTest(TestCase):
         )
         self.assertEqual(response.status_code, 200)
         self.assertIn("access", response.data)
+
+    def test_login_lockout_applies_to_active_user_token_route(self):
+        for _ in range(5):
+            response = self.client.post(
+                "/api/user/token/",
+                {
+                    "username": "authuser",
+                    "password": "wrong",
+                },
+                format="json",
+            )
+            self.assertEqual(response.status_code, 401)
+
+        lockout_response = self.client.post(
+            "/api/user/token/",
+            {
+                "username": "authuser",
+                "password": "wrong",
+            },
+            format="json",
+        )
+        self.assertEqual(lockout_response.status_code, 429)
+        self.assertEqual(lockout_response.data["code"], "account_locked")
 
 
 class PasswordResetTest(TestCase):


### PR DESCRIPTION
closes #36 
## Summary

This PR fixes a security gap where the real login route, `/api/user/token/`, was not covered by the brute-force lockout and auth-audit middleware.

## Problem

The middleware logic was hard-coded to `/api/token/`, but the frontend and backend currently use `/api/user/token/` for real user login. Because of that mismatch:

- failed login lockout did not apply to the active login route
- auth attempt audit logging did not consistently cover the real login flow
- maintenance/auth exemptions were not aligned with the active auth route structure

## Changes

- centralized auth-related route prefixes in `wordgen.middleware`
- updated login detection to cover both:
  - `/api/token/`
  - `/api/user/token/`
- updated auth-related exempt prefix handling to stay aligned with the active route structure
- added a regression test to verify lockout behavior on `/api/user/token/`

## Files Changed

- `Piicasso/backend/wordgen/middleware.py`
- `Piicasso/backend/wordgen/tests.py`

## Verification

- added a regression test for repeated failed login attempts on `/api/user/token/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Account lockout now applies consistently across all login authentication endpoints.

* **Refactor**
  * Standardized authentication middleware behavior for more consistent handling of exempt paths and login request detection.

* **Tests**
  * Added coverage for account lockout behavior on login routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->