### PR TITLE
Fix 500s in /api/operations/breach-search/ for valid email and non-email queries

### DIFF
--- a/Piicasso/backend/operations/tests.py
+++ b/Piicasso/backend/operations/tests.py
@@ -9,6 +9,7 @@ from django.contrib.auth.models import User
 from rest_framework.test import APIClient
 from operations.models import Notification, Message, SystemSetting
 from unittest.mock import patch
+import os
 
 
 class NotificationTest(TestCase):
@@ -112,8 +113,10 @@ class BreachSearchTest(TestCase):
         )
         self.assertEqual(response.status_code, 400)
 
+    @patch.dict(os.environ, {}, clear=False)
     @patch("operations.views.k_anonymity_breach_count", return_value=0)
     def test_breach_search_valid_email_does_not_500(self, mock_breach_count):
+        os.environ.pop("HIBP_API_KEY", None)
         response = self.client.post(
             "/api/operations/breach-search/",
             {"query": "person@example.com"},
@@ -123,15 +126,40 @@ class BreachSearchTest(TestCase):
         self.assertIn("risk_score", response.data)
         self.assertEqual(response.data["internal_matches"], 0)
 
-    def test_breach_search_password_check(self):
-        """Test password hash lookup (free API, no key needed)."""
+    @patch.dict(os.environ, {"HIBP_API_KEY": "test-key"}, clear=False)
+    @patch("requests.get")
+    @patch("operations.views.k_anonymity_breach_count", return_value=0)
+    def test_breach_search_email_uses_hibp_account_path(
+        self, mock_breach_count, mock_get
+    ):
+        mock_get.return_value.status_code = 404
+
+        response = self.client.post(
+            "/api/operations/breach-search/",
+            {"query": "person@example.com"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        mock_get.assert_called_once_with(
+            "https://haveibeenpwned.com/api/v3/breachedaccount/person%40example.com",
+            params={"truncateResponse": "true"},
+            headers={
+                "User-Agent": "PIIcasso-SecurityAudit",
+                "hibp-api-key": "test-key",
+            },
+            timeout=10,
+        )
+
+    @patch("operations.views.k_anonymity_breach_count", return_value=42)
+    def test_breach_search_password_check(self, mock_breach_count):
+        """Test password exposure handling without relying on the live HIBP API."""
         response = self.client.post(
             "/api/operations/breach-search/", {"query": "password123"}, format="json"
         )
         self.assertEqual(response.status_code, 200)
         self.assertIn("password_exposures", response.data)
-        # 'password123' should definitely be in breaches
-        self.assertGreater(response.data["password_exposures"], 0)
+        self.assertEqual(response.data["password_exposures"], 42)
 
     @patch("operations.views.k_anonymity_breach_count", return_value=0)
     def test_breach_search_non_email_uses_internal_matches_safely(

--- a/Piicasso/backend/operations/tests.py
+++ b/Piicasso/backend/operations/tests.py
@@ -8,6 +8,7 @@ from django.test import TestCase
 from django.contrib.auth.models import User
 from rest_framework.test import APIClient
 from operations.models import Notification, Message, SystemSetting
+from unittest.mock import patch
 
 
 class NotificationTest(TestCase):
@@ -111,6 +112,17 @@ class BreachSearchTest(TestCase):
         )
         self.assertEqual(response.status_code, 400)
 
+    @patch("operations.views.k_anonymity_breach_count", return_value=0)
+    def test_breach_search_valid_email_does_not_500(self, mock_breach_count):
+        response = self.client.post(
+            "/api/operations/breach-search/",
+            {"query": "person@example.com"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("risk_score", response.data)
+        self.assertEqual(response.data["internal_matches"], 0)
+
     def test_breach_search_password_check(self):
         """Test password hash lookup (free API, no key needed)."""
         response = self.client.post(
@@ -120,6 +132,17 @@ class BreachSearchTest(TestCase):
         self.assertIn("password_exposures", response.data)
         # 'password123' should definitely be in breaches
         self.assertGreater(response.data["password_exposures"], 0)
+
+    @patch("operations.views.k_anonymity_breach_count", return_value=0)
+    def test_breach_search_non_email_uses_internal_matches_safely(
+        self, mock_breach_count
+    ):
+        response = self.client.post(
+            "/api/operations/breach-search/", {"query": "password123"}, format="json"
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["internal_matches"], 0)
+        self.assertEqual(response.data["risk_score"], 0)
 
     def test_unauthenticated_breach_search(self):
         client = APIClient()

--- a/Piicasso/backend/operations/views.py
+++ b/Piicasso/backend/operations/views.py
@@ -8,6 +8,7 @@ from django.contrib.auth import get_user_model
 from django.db.models import Q
 import html as html_module
 import re
+from urllib.parse import quote
 from .models import Message, Notification, SystemSetting
 from .serializers import (
     MessageSerializer,
@@ -279,8 +280,8 @@ class BreachSearchView(APIView):
                         "hibp-api-key": hibp_api_key,
                     }
                     resp = http_requests.get(
-                        "https://haveibeenpwned.com/api/v3/breachedaccount/",
-                        params={"truncateResponse": "true", "account": query},
+                        f"https://haveibeenpwned.com/api/v3/breachedaccount/{quote(query, safe='')}",
+                        params={"truncateResponse": "true"},
                         headers=headers,
                         timeout=10,
                     )

--- a/Piicasso/backend/operations/views.py
+++ b/Piicasso/backend/operations/views.py
@@ -7,6 +7,7 @@ from rest_framework_simplejwt.authentication import JWTAuthentication
 from django.contrib.auth import get_user_model
 from django.db.models import Q
 import html as html_module
+import re
 from .models import Message, Notification, SystemSetting
 from .serializers import (
     MessageSerializer,
@@ -277,10 +278,6 @@ class BreachSearchView(APIView):
                         "User-Agent": "PIIcasso-SecurityAudit",
                         "hibp-api-key": hibp_api_key,
                     }
-                    # URL-encode the query to prevent injection
-                    from urllib.parse import quote
-
-                    safe_query = quote(query, safe="")
                     resp = http_requests.get(
                         "https://haveibeenpwned.com/api/v3/breachedaccount/",
                         params={"truncateResponse": "true", "account": query},
@@ -330,7 +327,7 @@ class BreachSearchView(APIView):
             100,
             (breach_count * 15)
             + (min(results["password_exposures"], 100) * 0.5)
-            + (internal_count * 5),
+            + (results["internal_matches"] * 5),
         )
         results["risk_score"] = round(risk_score)
 


### PR DESCRIPTION
## Summary

Fixes #38

This PR fixes server-side 500 errors in `/api/operations/breach-search/` caused by undefined names in the breach search handler.

## Problem

The endpoint could crash on normal requests in two ways:

- email queries could fail because `re.match(...)` was used without importing `re`
- non-email queries could fail because `risk_score` was still using `internal_count` after that variable had been removed

This made the endpoint unreliable and allowed ordinary requests to generate repeated 500 responses.

## Changes

- imported `re` in `Piicasso/backend/operations/views.py`
- replaced the stale `internal_count` reference with `results["internal_matches"]`
- removed the now-unused local URL-encoding code in the HIBP branch
- added regression tests for:
  - valid email queries
  - normal non-email queries
  - safe risk-score calculation when internal matches are unavailable

## Files Changed

- `Piicasso/backend/operations/views.py`
- `Piicasso/backend/operations/tests.py`

## Verification

Added regression tests covering both crash paths.

## Notes

Tests were not executed in this Codex session because the available Python environment here does not currently have Django installed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed breach-search to properly handle valid email queries and non-email inputs without errors
  * Corrected breach risk score calculation to accurately reflect internal matches

* **Tests**
  * Expanded breach-search test coverage for improved reliability across input types

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yokesh-kumar-M/Piicasso/pull/39)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->