### PR TITLE
fix(auth): return distinct login errors for missing account and wrong password

### DIFF
--- a/Piicasso/backend/wordgen/auth_views.py
+++ b/Piicasso/backend/wordgen/auth_views.py
@@ -53,11 +53,9 @@ class MyTokenObtainPairSerializer(TokenObtainPairSerializer):
         if not username or not password:
             raise AuthenticationFailed("Username/email and password are required.")
 
-        user = (
-            User.objects.filter(email__iexact=username).first()
-            if "@" in username
-            else User.objects.filter(username=username).first()
-        )
+        user = User.objects.filter(username=username).first()
+        if user is None:
+            user = User.objects.filter(email__iexact=username).first()
 
         if not user:
             # Keep timing similar when the account does not exist.

--- a/Piicasso/backend/wordgen/auth_views.py
+++ b/Piicasso/backend/wordgen/auth_views.py
@@ -8,6 +8,7 @@ from rest_framework.views import APIView
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 from rest_framework import status
+from rest_framework.exceptions import AuthenticationFailed
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError as DjangoValidationError
 from rest_framework_simplejwt.tokens import RefreshToken
@@ -17,7 +18,9 @@ from django.core.cache import cache
 import secrets
 import string
 from analytics.models import UserActivity
+from .backends import _DUMMY_HASH
 from .utils import safe_float
+from django.contrib.auth.hashers import check_password
 
 User = get_user_model()
 logger = logging.getLogger("wordgen")
@@ -44,7 +47,35 @@ class MyTokenObtainPairSerializer(TokenObtainPairSerializer):
         return token
 
     def validate(self, attrs):
-        data = super().validate(attrs)
+        username = attrs.get(self.username_field)
+        password = attrs.get("password")
+
+        if not username or not password:
+            raise AuthenticationFailed("Username/email and password are required.")
+
+        user = (
+            User.objects.filter(email__iexact=username).first()
+            if "@" in username
+            else User.objects.filter(username=username).first()
+        )
+
+        if not user:
+            # Keep timing similar when the account does not exist.
+            check_password(password, _DUMMY_HASH)
+            raise AuthenticationFailed("No account found for this email/username.")
+
+        if not user.check_password(password):
+            raise AuthenticationFailed("Incorrect password.")
+
+        if not user.is_active:
+            raise AuthenticationFailed("Your account has been suspended.")
+
+        self.user = user
+        refresh = self.get_token(user)
+        data = {
+            "refresh": str(refresh),
+            "access": str(refresh.access_token),
+        }
 
         data["username"] = self.user.username
         data["is_superuser"] = self.user.is_superuser

--- a/Piicasso/backend/wordgen/tests.py
+++ b/Piicasso/backend/wordgen/tests.py
@@ -130,6 +130,20 @@ class AuthTokenTest(TestCase):
             response.data["detail"], "No account found for this email/username."
         )
 
+    def test_login_unknown_username(self):
+        response = self.client.post(
+            "/api/user/token/",
+            {
+                "username": "missinguser",
+                "password": "wrong",
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(
+            response.data["detail"], "No account found for this email/username."
+        )
+
     def test_login_inactive_user(self):
         """1.3 fix: inactive users should NOT get valid tokens."""
         self.user.is_active = False

--- a/Piicasso/backend/wordgen/tests.py
+++ b/Piicasso/backend/wordgen/tests.py
@@ -114,6 +114,21 @@ class AuthTokenTest(TestCase):
             format="json",
         )
         self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.data["detail"], "Incorrect password.")
+
+    def test_login_unknown_email(self):
+        response = self.client.post(
+            "/api/user/token/",
+            {
+                "username": "missing@test.com",
+                "password": "wrong",
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(
+            response.data["detail"], "No account found for this email/username."
+        )
 
     def test_login_inactive_user(self):
         """1.3 fix: inactive users should NOT get valid tokens."""
@@ -128,6 +143,7 @@ class AuthTokenTest(TestCase):
             format="json",
         )
         self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.data["detail"], "Your account has been suspended.")
 
     def test_token_refresh(self):
         login = self.client.post(


### PR DESCRIPTION
## Summary

Fixes #46

Manual login was returning the same generic error for multiple failure cases:
`No active account found with the given credentials`

This PR updates the token login flow to return distinct responses for:
- non-existent email/username
- incorrect password
- suspended account

## Changes

- updated `MyTokenObtainPairSerializer` to validate the login identifier and password explicitly before issuing tokens
- return `No account found for this email/username.` when the account does not exist
- return `Incorrect password.` when the password is wrong
- return `Your account has been suspended.` for inactive users
- added regression tests covering the new login error responses

## Verification

- ran `manage.py test`
- result: `75` tests passed locally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Login now returns clearer, specific error messages for incorrect password, unknown account, and suspended accounts.

* **Security**
  * Hardened authentication checks to resist timing attacks and more strictly validate credentials.

* **Tests**
  * Added and updated token/auth tests to assert precise error messages for unknown accounts, wrong passwords, and inactive accounts.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yokesh-kumar-M/Piicasso/pull/47)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->