### PR TITLE
fix(deps): patch 32/33 Snyk pip findings + add CI Snyk gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,11 @@ jobs:
   backend-tests:
     runs-on: ubuntu-latest
 
+    env:
+      # Mapped from the repo secret so step-level `if` can skip the Snyk gate
+      # gracefully when the token is absent (e.g. fork / Dependabot PRs).
+      SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+
     services:
       postgres:
         image: postgres:15
@@ -91,8 +96,23 @@ jobs:
           pip install pip-audit
           pip-audit --strict --requirement requirements.txt || true
 
+      - name: Snyk test (gate on high/critical Python deps)
+        if: ${{ env.SNYK_TOKEN != '' }}
+        run: |
+          cd Piicasso/backend
+          npm install -g snyk
+          # Deps were installed in the "Install dependencies" step above, so
+          # Snyk reads the resolved versions from requirements.txt rather than a
+          # stale environment. The medium 'twisted' command-injection advisory
+          # (SNYK-PYTHON-TWISTED-12671201) has no upstream fix and sits below
+          # this threshold by design — the build fails only on high/critical.
+          snyk test --severity-threshold=high
+
   frontend-tests:
     runs-on: ubuntu-latest
+
+    env:
+      SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 
     steps:
       - uses: actions/checkout@v6
@@ -130,3 +150,10 @@ jobs:
         run: |
           cd Piicasso/frontend
           npm audit --audit-level=high || true
+
+      - name: Snyk test (gate on high/critical npm deps)
+        if: ${{ env.SNYK_TOKEN != '' }}
+        run: |
+          cd Piicasso/frontend
+          npm install -g snyk
+          snyk test --severity-threshold=high

--- a/Piicasso/backend/requirements.txt
+++ b/Piicasso/backend/requirements.txt
@@ -23,7 +23,7 @@ redis>=5.2.1,<6
 whitenoise==6.8.2
 
 # Security & auth
-PyJWT==2.12.1  # security: PYSEC-2026-120, PYSEC-2025-183
+PyJWT==2.13.0  # security: PYSEC-2026-120/175/177/178/179, PYSEC-2025-183 (2.13.0 closes the full SNYK pyjwt set)
 cryptography>=46.0.6,<47  # security: PYSEC-2026-35, CVE-2024-12797, CVE-2026-26007
 # django-cryptography was unused (only `cryptography.fernet.Fernet` is imported
 # directly by generator/fields.py) and the upstream package is unmaintained
@@ -35,7 +35,9 @@ google-generativeai==0.8.3
 
 # HTTP clients
 requests==2.33.0  # security: CVE-2024-47081, CVE-2026-25645
-urllib3>=2.2.0,<3
+# security: floor raised to 2.7.0 — <2.7.0 is vulnerable to data-amplification
+# (SNYK-PYTHON-URLLIB3 highly-compressed-data) and sensitive-info leakage on redirect
+urllib3>=2.7.0,<3
 
 # PDF / Report generation
 reportlab==4.2.5
@@ -66,4 +68,15 @@ daphne==4.1.2
 # Transitive deps of the daphne/channels websocket stack, pinned to patched
 # releases for security. Not imported directly by application code.
 Twisted>=26.4.0  # security: PYSEC-2026-160
+# Note: twisted still carries one un-patched advisory (SNYK-PYTHON-TWISTED-12671201,
+# "Arbitrary Command Injection", medium) with no fixed release as of 2026-06; not
+# reachable from this app's code paths — accepted until upstream ships a fix.
 pyOpenSSL>=26.0.0  # security: CVE-2026-27448, CVE-2026-27459
+
+# Vulnerable transitive deps pinned to patched floors. Not imported directly by
+# application code; without these the resolver pulls older, flagged versions.
+click>=8.3.3      # security: SNYK-PYTHON-CLICK-16347201 (command injection) — via celery
+idna>=3.15        # security: SNYK-PYTHON-IDNA-16769942 (ReDoS) — via requests
+pyasn1>=0.6.3     # security: SNYK-PYTHON-PYASN1-15032639/15674561 — via google-auth
+sqlparse>=0.5.4   # security: SNYK-PYTHON-SQLPARSE-14157217 — via django
+ujson>=5.12.1     # security: SNYK-PYTHON-UJSON-16643463 — via daphne -> autobahn


### PR DESCRIPTION
## Summary

Snyk reported **33 known vulnerabilities** in the backend pip project (`Piicasso/backend/requirements.txt`). Both npm projects (`frontend`, `cli-node`) scan clean. This PR resolves **32 of 33** (the remaining one has no upstream fix) **and** adds a Snyk gate to CI to prevent regressions.

Snyk's pip scanner reads the *installed* environment, so several findings were stale-env artifacts already covered by existing pins. This change addresses the deps that genuinely still needed a bump or were unpinned transitively.

## Dependency changes (`requirements.txt`)

| Package | Change | Findings closed |
|---|---|---|
| `PyJWT` | `2.12.1` → `2.13.0` | 7 |
| `urllib3` | floor `>=2.2.0` → `>=2.7.0` | 4 |
| `click` (transitive, via celery) | add `>=8.3.3` | 1 |
| `idna` (transitive, via requests) | add `>=3.15` | 1 |
| `pyasn1` (transitive, via google-auth) | add `>=0.6.3` | 2 |
| `sqlparse` (transitive, via django) | add `>=0.5.4` | 1 |
| `ujson` (transitive, via daphne→autobahn) | add `>=5.12.1` | 1 |

The other **15 findings** (cryptography, pillow, pyOpenSSL, requests, python-dotenv, simplejwt, twisted-algorithmic) were already covered by existing pins and only surfaced because the scanned local env was stale — a clean install clears them.

## CI gate

Adds `snyk test --severity-threshold=high` to both the `backend-tests` and `frontend-tests` jobs (`.github/workflows/ci.yml`):

- **Backend** runs it *after* `pip install -r requirements.txt`, so Snyk reads the resolved versions rather than a stale env.
- **Token-guarded**: a job-level `SNYK_TOKEN` env (from the repo secret) plus a step `if: ${{ env.SNYK_TOKEN != '' }}` means the gate skips gracefully on fork/Dependabot PRs and until the secret is configured — never a false failure.
- **High/critical threshold** keeps the build green on the one medium Twisted advisory below.

> **Action required to activate the gate:** add a `SNYK_TOKEN` repository secret (Settings → Secrets and variables → Actions). Until then the Snyk steps are skipped and the rest of CI runs unchanged.

## Verification

Built a fresh venv from the updated `requirements.txt` and re-ran `snyk test`:

```
Before: uniqueCount = 33
After:  uniqueCount = 1
```

## Remaining (1, accepted)

`twisted` — **Arbitrary Command Injection** (`SNYK-PYTHON-TWISTED-12671201`, medium). No fixed release exists upstream as of 2026-06, including on the latest `26.4.0`. Not reachable from this app's code paths; documented inline in `requirements.txt` and kept below the CI severity threshold.
