### PR TITLE
fix(profile): send current_password when changing email

### DIFF
--- a/Piicasso/frontend/src/pages/ProfilePage.js
+++ b/Piicasso/frontend/src/pages/ProfilePage.js
@@ -35,6 +35,9 @@ const ProfilePage = () => {
     const [passwordForm, setPasswordForm] = useState({ current_password: '', new_password: '', confirm_password: '' });
     const [passwordError, setPasswordError] = useState('');
     const [passwordSuccess, setPasswordSuccess] = useState('');
+    // Current password required to re-authenticate an email change (backend
+    // anti-takeover check). Kept separate from the password-change form above.
+    const [emailChangePassword, setEmailChangePassword] = useState('');
 
     useEffect(() => {
         const fetchData = async () => {
@@ -74,15 +77,35 @@ const ProfilePage = () => {
         if (user?.profile_picture) setAvatarPreview(user.profile_picture);
     }, [user]);
 
+    // True when the edited email differs from the stored one. Changing the email
+    // requires the account password (the backend rejects the change otherwise),
+    // so we prompt for it and include it in the PATCH only in that case.
+    const emailChanged =
+        editForm.email.trim().toLowerCase() !== (profile?.email || '').toLowerCase();
+
     const handleSaveProfile = async () => {
-        setSaving(true);
         setEditError('');
         setEditSuccess('');
+
+        if (emailChanged) {
+            // OAuth accounts have no usable password and cannot change email.
+            if (profile?.has_usable_password === false) {
+                setEditError('Email cannot be changed for Google OAuth accounts.');
+                return;
+            }
+            if (!emailChangePassword) {
+                setEditError('Enter your current password to change your email.');
+                return;
+            }
+        }
+
+        setSaving(true);
         try {
             const formData = new FormData();
             formData.append('first_name', editForm.first_name);
             formData.append('last_name', editForm.last_name);
             formData.append('email', editForm.email);
+            if (emailChanged) formData.append('current_password', emailChangePassword);
             if (avatarFile) formData.append('profile_picture', avatarFile);
 
             await axiosInstance.patch('profile/', formData, {
@@ -90,6 +113,7 @@ const ProfilePage = () => {
             });
             setEditSuccess('Profile updated successfully!');
             setEditing(false);
+            setEmailChangePassword('');
             const res = await axiosInstance.get('profile/');
             setProfile(res.data);
             setTimeout(() => setEditSuccess(''), 3000);
@@ -341,7 +365,7 @@ const ProfilePage = () => {
                                     zIndex: 10,
                                 }}>
                                     <button
-                                        onClick={() => { setEditing(!editing); setEditError(''); }}
+                                        onClick={() => { setEditing(!editing); setEditError(''); setEmailChangePassword(''); }}
                                         style={{
                                             width: '100%',
                                             borderRadius: 6,
@@ -590,6 +614,41 @@ const ProfilePage = () => {
                                             />
                                         </div>
                                     </div>
+                                    {emailChanged && profile?.has_usable_password !== false && (
+                                        <div style={{ marginTop: 16 }}>
+                                            <label style={{
+                                                fontSize: 10,
+                                                fontFamily: 'var(--font-mono)',
+                                                textTransform: 'uppercase',
+                                                letterSpacing: 1,
+                                                marginBottom: 6,
+                                                display: 'block',
+                                                color: 'var(--fg-3)',
+                                            }}>
+                                                Current Password — required to change email
+                                            </label>
+                                            <input
+                                                type="password"
+                                                value={emailChangePassword}
+                                                onChange={e => setEmailChangePassword(e.target.value)}
+                                                autoComplete="current-password"
+                                                style={{
+                                                    width: '100%',
+                                                    padding: '10px 12px',
+                                                    fontSize: 14,
+                                                    borderRadius: 6,
+                                                    background: 'var(--ink-3)',
+                                                    border: '1px solid var(--ink-5)',
+                                                    color: 'var(--fg-0)',
+                                                    outline: 'none',
+                                                    transition: 'border-color 200ms',
+                                                }}
+                                                onFocus={(e) => e.target.style.borderColor = 'var(--accent-500)'}
+                                                onBlur={(e) => e.target.style.borderColor = 'var(--ink-5)'}
+                                                placeholder="Enter current password to confirm"
+                                            />
+                                        </div>
+                                    )}
                                     <button
                                         onClick={handleSaveProfile}
                                         disabled={saving}


### PR DESCRIPTION
## What

The profile email-edit form now collects and sends `current_password` when the user changes their email.

## Why

PR #67 hardens `PUT/PATCH /api/profile/` to require the account password before an email change (anti-takeover). The SPA form only sent name / email / avatar, so once #67 lands, **any email change from the profile page would fail with `400 "Current password is required to change email."`** This closes that gap — it's the frontend half of that breaking change.

## How

- `ProfilePage` computes `emailChanged` (case-insensitive, matching the backend) and reveals a required **Current Password** field only when the email is actually being changed.
- The password is appended to the multipart PATCH only on an email change — name/avatar-only updates are unaffected and never prompt.
- OAuth accounts (no usable password) are blocked client-side with a clear message, mirroring the backend.
- The field is cleared on save success and when editing is cancelled.

## Compatibility / merge order

Forward- and backward-compatible. On today's prod backend (no email-password check yet) the extra `current_password` field is simply ignored, so this is safe to merge at any time. Once #67 merges, the field is enforced and the flow works end-to-end.

**Recommend merging this together with or before #67** to avoid a window where the backend requires a password the old frontend doesn't send.

## Verification

- `npm run build` (vite) — passes
- `npm test` (vitest) — passes (2/2)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Email changes now require current password verification for security purposes.
  * Current password input field appears when editing your email address in account settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->